### PR TITLE
fix: add "holes" to marks

### DIFF
--- a/src/syntax-extensions/BoldExtension.ts
+++ b/src/syntax-extensions/BoldExtension.ts
@@ -61,7 +61,7 @@ export class BoldExtension extends MarkExtension<Strong> {
         },
       ],
       toDOM(): DOMOutputSpec {
-        return ["strong"];
+        return ["strong", 0];
       },
     };
   }

--- a/src/syntax-extensions/InlineCodeExtension.ts
+++ b/src/syntax-extensions/InlineCodeExtension.ts
@@ -48,7 +48,7 @@ export class InlineCodeExtension extends MarkExtension<InlineCode> {
       inclusive: false,
       parseDOM: [{ tag: "code" }],
       toDOM(): DOMOutputSpec {
-        return ["code"];
+        return ["code", 0];
       },
     };
   }

--- a/src/syntax-extensions/ItalicExtension.ts
+++ b/src/syntax-extensions/ItalicExtension.ts
@@ -61,7 +61,7 @@ export class ItalicExtension extends MarkExtension<Emphasis> {
         },
       ],
       toDOM(): DOMOutputSpec {
-        return ["em"];
+        return ["em", 0];
       },
     };
   }

--- a/src/syntax-extensions/LinkExtension.ts
+++ b/src/syntax-extensions/LinkExtension.ts
@@ -50,7 +50,7 @@ export class LinkExtension extends MarkExtension<Link> {
         },
       ],
       toDOM(node: Mark): DOMOutputSpec {
-        return ["a", node.attrs];
+        return ["a", node.attrs, 0];
       },
     };
   }

--- a/src/syntax-extensions/StrikethroughExtension.ts
+++ b/src/syntax-extensions/StrikethroughExtension.ts
@@ -59,7 +59,7 @@ export class StrikethroughExtension extends MarkExtension<Delete> {
         },
       ],
       toDOM(): DOMOutputSpec {
-        return ["s"];
+        return ["s", 0];
       },
     };
   }


### PR DESCRIPTION
While using this library together with [`handlewithcarecollective/react-prosemirror`](https://github.com/handlewithcarecollective/react-prosemirror), I noticed the selected content would be removed from the view if I toggle the marks. I took a look into the schema and found that no holes are defined in the [`toDOM` method](https://prosemirror.net/docs/ref/#model.NodeSpec.toDOM) of these marks. This PR fixed them.

One thing I didn't look into further is that this library works well with the [nytimes/react-prosemirror](https://github.com/nytimes/react-prosemirror) and I'm not sure about why.