### PR TITLE
Fixes for TaskListItemExtension

### DIFF
--- a/src/syntax-extensions/TaskListItemExtension.ts
+++ b/src/syntax-extensions/TaskListItemExtension.ts
@@ -105,19 +105,23 @@ export class TaskListItemExtension extends NodeExtension<ListItem> {
   ): Array<InputRule> {
     return [
       new InputRule(/^\[([x\s]?)\][\s\S]$/u, (state, match, start) => {
-        const wrappingNode = state.doc.resolve(start).node(-1);
-        if (wrappingNode.type.name !== "regular_list_item") {
-          return null;
-        }
-        return state.tr.replaceRangeWith(
-          start - 2,
-          start + wrappingNode.nodeSize,
-          proseMirrorSchema.nodes[this.proseMirrorNodeName()].create(
-            { checked: match[1] === "x" },
-            wrappingNode.content.cut(3 + match[1].length),
-          ),
-        );
-      }),
+          const resolvedPos = state.doc.resolve(start);
+          const wrappingNode = resolvedPos.node(-1);
+          if (wrappingNode.type.name !== "regular_list_item") {
+            return null;
+          }
+  
+          const regularListItemStartPos = resolvedPos.before(-1);
+          const regularListItemEndPos = resolvedPos.after(-1);
+          return state.tr.replaceRangeWith(
+            regularListItemStartPos,
+            regularListItemEndPos,
+            proseMirrorSchema.nodes[this.proseMirrorNodeName()].create(
+              { checked: match[1] === "x" },
+              wrappingNode.content.cut(3 + match[1].length),
+            ),
+          );
+        }),
     ];
   }
 


### PR DESCRIPTION
When trying to use TaskListItemExtension in my own project, I was getting RangeErrors from ProseMirror when creating the task list item and also when executing the Backspace handler. I believe these were due to differences in the structure of my document vs the structure that the TaskListItemExtension was expecting. The approach I am taking here uses built in methods of ProseMirror to calculate the start and end positions for replacement and will hopefully be resilient to more edge cases.

Additionally, I found that adding the Enter, Shift-Tab, and Tab behaviors make task lists a lot nicer to work with. I have included those changes in a separate commit however, so they can be applied separately.

I also would propose removing the Backspace behavior, since things seem to work in a more standard way if I take it out - however, I am simply fixing it for now.