### PR TITLE
Bump prosemirror-inputrules version to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "micromark-extension-gfm-strikethrough": "^2.0.0",
         "micromark-extension-gfm-task-list-item": "^2.0.1",
         "prosemirror-commands": "^1.5.1",
-        "prosemirror-inputrules": "^1.2.0",
+        "prosemirror-inputrules": "^1.4.0",
         "prosemirror-schema-list": "^1.2.2",
         "prosemirror-unified": "=0.8.1",
         "remark-parse": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "micromark-extension-gfm-strikethrough": "^2.0.0",
     "micromark-extension-gfm-task-list-item": "^2.0.1",
     "prosemirror-commands": "^1.5.1",
-    "prosemirror-inputrules": "^1.2.0",
+    "prosemirror-inputrules": "^1.4.0",
     "prosemirror-schema-list": "^1.2.2",
     "prosemirror-unified": "=0.8.1",
     "remark-parse": "^11.0.0",


### PR DESCRIPTION
Bumping prosemirror-inputrules version to 1.4.0 to take advantage of this fix: https://github.com/ProseMirror/prosemirror-inputrules/pull/8
