### PR TITLE
Migrate coverage reporting from Coveralls to Codecov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,6 +87,7 @@ jobs:
           npm run test-coverage
 
       - name: "Upload coverage results"
-        uses: coverallsapp/github-action@v2.3.8
+        uses: codecov/codecov-action@v7.0.0
         with:
-          debug: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM Version](https://img.shields.io/npm/v/prosemirror-remark?logo=npm)](https://www.npmjs.com/package/prosemirror-remark)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/marekdedic/prosemirror-remark/CI.yml?branch=master&logo=github)](https://github.com/marekdedic/prosemirror-remark/actions/workflows/CI.yml)
-[![Coveralls](https://img.shields.io/coverallsCoverage/github/marekdedic/prosemirror-remark?branch=master&logo=coveralls)](https://coveralls.io/github/marekdedic/prosemirror-remark)
+[![Codecov (with branch)](https://img.shields.io/codecov/c/github/marekdedic/prosemirror-remark/master?logo=codecov)](https://app.codecov.io/gh/marekdedic/prosemirror-remark)
 [![NPM Downloads](https://img.shields.io/npm/dm/prosemirror-remark?logo=npm)](https://www.npmjs.com/package/prosemirror-remark)
 [![NPM License](https://img.shields.io/npm/l/prosemirror-remark)](https://github.com/marekdedic/prosemirror-remark/blob/master/LICENSE)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 ---
 coverage:
-  range: "95...100"
+  range: "0...100"
 
   status:
     project:
@@ -9,7 +9,7 @@ coverage:
         threshold: 5%
     patch:
       default:
-        target: 90%
+        target: 0%
 
 parsers:
   gcov:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+---
+coverage:
+  range: "95...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        target: 90%
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: true
+      loop: true
+      method: false
+      macro: false
+
+comment:
+  layout: "reach,diff,flags,files"
+  require_changes: false


### PR DESCRIPTION
Two commits; they can be reviewed separately.

## 1. `Migrate coverage reporting from Coveralls to Codecov`

Unify coverage reporting on Codecov, which the other repositories already
use, so that all of them report to a single service.

- Replace `coverallsapp/github-action` with `codecov/codecov-action`,
  configured as in the other repositories: an authentication token from
  `secrets.CODECOV_TOKEN` and `fail_ci_if_error: true`.
- Add `codecov.yml`, identical to the one in the other repositories.
- Point the README coverage badge at Codecov.

## 2. `Don't enforce high coverage for now`

Coverage currently stands at 89.1 %, below the 95...100 range and the 90 %
patch target that the strict configuration expects. Use the permissive
configuration instead, identical to the one in handbook-api and
skaut-google-drive-gallery:

- `range: "0...100"`, so the reported figure is not painted as failing.
- `patch` target `0%`, so a pull request is never blocked for adding code
  below the threshold.

The `project` status keeps `target: auto` with a 5 % threshold, so a
significant regression is still reported. This is meant to be temporary --
the strict configuration should come back once coverage is high enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)