### PR TITLE
Don't count test helpers in coverage

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,9 @@ export default defineConfig({
   },
   plugins: [dts({ bundleTypes: true })],
   test: {
+    coverage: {
+      exclude: ["tests/**"],
+    },
     environment: "jsdom",
     mockReset: true,
   },


### PR DESCRIPTION
The tests directory was being measured as if it were production code.
Vitest's default `coverage.exclude` matches test *file name* patterns
(`**/*.{test,spec}.*`) rather than test *directories*, so files under
`tests/` that don't carry `.test.` in their name were instrumented, because
the tests import them.

In this repository 8 of the 33 measured files were the testers under
`tests/utils/`, accounting for 42 % of the measured lines. Locally, line
coverage goes from 94.65 % to 94.24 % once they are excluded — the helpers
were themselves well covered, so they were quietly inflating the figure
while masking gaps in `src/`.

Exclude `tests/**` from coverage. Doing this in the vitest config rather than
through `codecov.yml`'s `ignore` key keeps a local `npm run test-coverage` run
consistent with CI, and leaves `codecov.yml` byte-identical across all the
repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)