### PR TITLE
Removed obsolete forceConsistentCasingInFileNames

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "moduleResolution": "bundler",
     "target": "es6",


### PR DESCRIPTION
`forceConsistentCasingInFileNames` defaults to `true` on TypeScript 6, so setting it explicitly does nothing:

```
$ tsc --all
--forceConsistentCasingInFileNames
default: true
```

It was also inconsistent across the repos — set in 12 of the 15 tsconfigs, absent from crdm-modern, skautis-integration and skaut-google-drive-gallery — which made it read as accidental rather than deliberate, in the part of the config that is meant to be per-repo. Removing it everywhere resolves that.

No behaviour change. Verified that the typecheck and eslint both pass before and after.