### PR TITLE
Canonical casing in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "bundler",
-    "target": "es6",
+    "target": "es2015",
     "types": [],
 
     "allowUnreachableCode": false,


### PR DESCRIPTION
Normalises the tsconfig enum values to the spelling and casing that the [SchemaStore `tsconfig` schema](https://json.schemastore.org/tsconfig) — the one editors validate against — defines. It is not one blanket casing; it differs per option:

| Option | Standard casing | Examples |
| --- | --- | --- |
| `target` | lowercase | `es5`, `es2015`, `esnext` |
| `module` | lowercase | `commonjs`, `es2015`, `nodenext` |
| `moduleResolution` | lowercase | `bundler`, `nodenext` |
| `jsx` | lowercase | `react-jsx` |
| `lib` | **PascalCase** | `ES5`, `ES2015`, `ESNext`, `DOM`, `DOM.Iterable`, `ScriptHost` |

`lib` is the outlier deliberately — its values are dotted sub-libraries (`ES2015.Symbol.WellKnown`, `DOM.AsyncIterable`) where the PascalCase segments carry meaning. `tsc --init` on 6.0.3 independently emits lowercase for the other four (`"module": "nodenext"`, `"target": "esnext"`, `"jsx": "react-jsx"`).

`ES2015` rather than `ES6`: both are accepted, but `es6`/`es7` are legacy aliases kept only for the first two versions — everything from `es2017` on has only the year form, and the lib file `"es6"` resolves to is itself named `lib.es2015.d.ts`.

TypeScript is case-insensitive for all of these, so **no behaviour change**. Verified two ways: the typecheck passes before and after, and `tsc --listFiles` resolves an identical set of `lib.*.d.ts` files before and after.