### PR TITLE
Raise the ES target to ES2018 and pin build.target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "bundler",
-    "target": "es2015",
+    "target": "es2018",
 
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,8 @@ export default defineConfig({
         "unified",
       ],
     },
+    // Matches `unified`, which ships ES2018.
+    target: "es2018",
   },
   plugins: [dts({ bundleTypes: true })],
   test: {


### PR DESCRIPTION
Two problems, one fix.

`tsconfig.json` declared `"target": "es2015"`, but under Vite that governs **typechecking only**. The actual emit came from Vite 8's default `build.target` of `baseline-widely-available` — `chrome111, edge111, firefox114, safari16.4`, roughly ES2022.

So the published bundle has been shipping ES2022 while the repo claimed ES2015. The declared number was both wrong and drifting: it would move again on the next Vite major without anyone touching this repo.

## Why ES2018 rather than restoring ES2015

ES2015 was never backed by the artifact, and nothing in the ecosystem needs it. I scanned what the surrounding packages actually publish:

- `unified` — ES2018
- `prosemirror-commands` — ES2018
- `prosemirror-model`, `prosemirror-view` — plain ES2015

ES2018 matches the ceiling of what this package already sits on top of. Consumers re-bundle to their own target regardless, so the only real obligation is not out-running their parsers, and matching the ecosystem does that without pretending to a floor nothing enforces.

## Effect on the bundle

| | default (before) | `es2018` (after) |
|---|---|---|
| `??` in dist | present | downlevelled |

(There is one `?.` left in `dist`, but it is inside a regex character class in the bundled `escape-string-regexp` — `/[|\\{}()[\]^$+*?.]/g` — not optional chaining.)

## Verification

- `npm run lint` — 0 errors (3 pre-existing `TODO` warnings in tests, untouched)
- `npx vitest run` — 444 tests across 22 files pass
- `npm run build` produces both ESM and CJS as before