### PR TITLE
Convert ESLint config to TypeScript

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -8,10 +8,10 @@ import packageJson from "eslint-plugin-package-json";
 import perfectionist from "eslint-plugin-perfectionist";
 import preferArrowFunctions from "eslint-plugin-prefer-arrow-functions";
 import prettierRecommended from "eslint-plugin-prettier/recommended";
-import { globalIgnores } from "eslint/config";
+import { defineConfig, globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   globalIgnores(["coverage/", "dist/", "package-lock.json"]),
   packageJson.configs.recommended,
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "eslint-plugin-perfectionist": "^5.0.0",
         "eslint-plugin-prefer-arrow-functions": "^3.4.0",
         "eslint-plugin-prettier": "^5.0.0",
+        "jiti": "^2.7.0",
         "jsdom": "^30.0.1",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.1.0",
@@ -3593,6 +3594,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/jju": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "eslint-plugin-perfectionist": "^5.0.0",
     "eslint-plugin-prefer-arrow-functions": "^3.4.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "jiti": "^2.7.0",
     "jsdom": "^30.0.1",
     "mdast-util-from-markdown": "^2.0.0",
     "mdast-util-to-markdown": "^2.1.0",


### PR DESCRIPTION
Renames eslint.config.js→.ts, adds the jiti devDep ESLint needs to load a TS config, and migrates tseslint.config() to defineConfig() — a deprecation the type-checked .ts config surfaces. Verified eslint passes.